### PR TITLE
EUTHEME-188 (Language switcher in the europa theme)

### DIFF
--- a/template.php
+++ b/template.php
@@ -683,13 +683,13 @@ function europa_preprocess_block(&$variables) {
       break;
 
     case 'language_selector_site':
-      $variables['lang_code'] = $lang_code = $variables['elements']['code']['#markup'];
+      $variables['lang_code'] = $variables['elements']['code']['#markup'];
       $variables['lang_name'] = $variables['elements']['label']['#markup'];
       // Add class to block.
       $link = url('splash');
       $variables['classes_array'][] = 'lang-select-site';
       $destination = drupal_get_destination()['destination'];
-      $variables['link'] = $link . '_' . $lang_code . '?' . $destination;
+      $variables['link'] = $link . '?' . $destination;
       break;
   }
 

--- a/template.php
+++ b/template.php
@@ -681,6 +681,16 @@ function europa_preprocess_block(&$variables) {
       $variables['classes_array'][] = 'link-block';
       $variables['title_attributes_array']['class'][] = 'link-block__title';
       break;
+
+    case 'language_selector_site':
+      $variables['lang_code'] = $lang_code = $variables['elements']['code']['#markup'];
+      $variables['lang_name'] = $variables['elements']['label']['#markup'];
+      // Add class to block.
+      $link = url('splash');
+      $variables['classes_array'][] = 'lang-select-site';
+      $destination = drupal_get_destination()['destination'];
+      $variables['link'] = $link . '_' . $lang_code . '?' . $destination;
+      break;
   }
 
   // Page-level language switcher.

--- a/template.php
+++ b/template.php
@@ -686,10 +686,8 @@ function europa_preprocess_block(&$variables) {
       $variables['lang_code'] = $variables['elements']['code']['#markup'];
       $variables['lang_name'] = $variables['elements']['label']['#markup'];
       // Add class to block.
-      $link = url('splash');
       $variables['classes_array'][] = 'lang-select-site';
-      $destination = drupal_get_destination()['destination'];
-      $variables['link'] = $link . '?' . $destination;
+      $variables['link'] = url('splash') . '?' . drupal_get_destination()['destination'];
       break;
   }
 

--- a/templates/block/block--language-selector-site.tpl.php
+++ b/templates/block/block--language-selector-site.tpl.php
@@ -54,4 +54,5 @@
       <span class="lang-select-site__code-text"><?php print $lang_code; ?></span>
     </span>
   </a>
+  <div class="splash-page splash-page--overlay"></div>
 </section>

--- a/templates/block/block--language-selector-site.tpl.php
+++ b/templates/block/block--language-selector-site.tpl.php
@@ -47,7 +47,7 @@
  */
 ?>
 <section class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
-  <a href="<?php print $link ?>" class="lang-select-site__link">
+  <a href="<?php print $link; ?>" class="lang-select-site__link">
     <span class="lang-select-site__label"><?php print $lang_name; ?></span>
     <span class="lang-select-site__code">
       <span class="icon icon--language lang-select-site__icon"></span>

--- a/templates/block/block--language-selector-site.tpl.php
+++ b/templates/block/block--language-selector-site.tpl.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @file
+ * Default theme implementation to display a block.
+ *
+ * Available variables:
+ * - $block->subject: Block title.
+ * - $content: Block content.
+ * - $block->module: Module that generated the block.
+ * - $block->delta: An ID for the block, unique within each module.
+ * - $block->region: The block region embedding the current block.
+ * - $classes: String of classes that can be used to style contextually through
+ *   CSS. It can be manipulated through the variable $classes_array from
+ *   preprocess functions. The default values can be one or more of the
+ *   following:
+ *   - block: The current template type, i.e., "theming hook".
+ *   - block-[module]: The module generating the block. For example, the user
+ *     module is responsible for handling the default user navigation block. In
+ *     that case the class would be 'block-user'.
+ * - $title_prefix (array): An array containing additional output populated by
+ *   modules, intended to be displayed in front of the main title tag that
+ *   appears in the template.
+ * - $title_suffix (array): An array containing additional output populated by
+ *   modules, intended to be displayed after the main title tag that appears in
+ *   the template.
+ *
+ * Helper variables:
+ * - $classes_array: Array of html class attribute values. It is flattened
+ *   into a string within the variable $classes.
+ * - $block_zebra: Outputs 'odd' and 'even' dependent on each block region.
+ * - $zebra: Same output as $block_zebra but independent of any block region.
+ * - $block_id: Counter dependent on each block region.
+ * - $id: Same output as $block_id but independent of any block region.
+ * - $is_front: Flags true when presented in the front page.
+ * - $logged_in: Flags true when the current user is a logged-in member.
+ * - $is_admin: Flags true when the current user is an administrator.
+ * - $block_html_id: A valid HTML ID and guaranteed unique.
+ *
+ * @see bootstrap_preprocess_block()
+ * @see template_preprocess()
+ * @see template_preprocess_block()
+ * @see bootstrap_process_block()
+ * @see template_process()
+ *
+ * @ingroup themeable
+ */
+?>
+<section class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
+  <a href="<?php print $link ?>" class="lang-select-site__link">
+    <span class="lang-select-site__label"><?php print $lang_name; ?></span>
+    <span class="lang-select-site__code">
+      <span class="icon icon--language lang-select-site__icon"></span>
+      <span class="lang-select-site__code-text"><?php print $lang_code; ?></span>
+    </span>
+  </a>
+</section>


### PR DESCRIPTION
## Issue [EUTHEME-188](https://webgate.ec.europa.eu/CITnet/jira/browse/EUTHEME-188)

**Notes:**
This has not been included in any context, for now, to test it please add the language switcher site block to the the header region.
Furthermore, this is only providing the right "style" for the component, it coould work as a language switcher enabling the splash_page feature, but due to the way it is themed by the europa theme it requires, at the moment, the dt_language_selector_site_popup module which is not part of the stack.