### PR TITLE
EUTHEME- 234 (Adding a setting for hiding the site identification in the home page)

### DIFF
--- a/europa.info
+++ b/europa.info
@@ -99,7 +99,6 @@ settings[ec_europa_improved_website] = 0
 settings[ec_europa_breadcrumb_menu] = menu-breadcrumb-menu
 settings[ec_europa_improved_website_home] = 1
 
-
 ; Breakpoints
 ; --------------
 breakpoints[wide] = only screen and (min-width: 992px)

--- a/europa.info
+++ b/europa.info
@@ -96,7 +96,8 @@ settings[ec_europa_site_switcher] = informational
 settings[ec_europa_user_menu] = 0
 settings[ec_europa_user_login] = 0
 settings[ec_europa_improved_website] = 0
-settings[ec_europa_breadcrumb_menu] = 'menu-breadcrumb-menu'
+settings[ec_europa_breadcrumb_menu] = menu-breadcrumb-menu
+settings[ec_europa_improved_website_home] = 1
 
 
 ; Breakpoints

--- a/templates/system/page.tpl.php
+++ b/templates/system/page.tpl.php
@@ -151,19 +151,21 @@
   <!-- Page Header -->
   <div class="page-header <?php if (isset($header_back)) : print ' page-header--image';
  endif; ?>">
-    <?php if (!empty($page['header_bottom'])): ?>
-      <nav class="page-navigation" role="navigation">
-        <div class="container-fluid">
-          <?php print render($page['header_bottom']); ?>
-        </div>
-      </nav>
-    <?php endif; ?>
+  <?php if (!empty($page['header_bottom'])): ?>
+    <nav class="page-navigation" role="navigation">
+      <div class="container-fluid">
+        <?php print render($page['header_bottom']); ?>
+      </div>
+    </nav>
+  <?php endif; ?>
     
-    <?php if (theme_get_setting('ec_europa_improved_website', 'europa')): ?>
+  <?php if (theme_get_setting('ec_europa_improved_website', 'europa')): ?>
+    <?php if (!$is_front || $is_front && theme_get_setting('ec_europa_improved_website_home', 'europa')): ?>
     <div class="container-fluid page-header__site-identification">
       <h3><?php print $site_name; ?></h3>
     </div>
     <?php endif; ?>
+  <?php endif; ?>
     
     <div class="container-fluid page-header__hero-title">
       <div class="row padding-reset">

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -22,7 +22,7 @@ function europa_form_system_theme_settings_alter(&$form, &$form_state) {
     '#title' => t('Check the menu to be used at the beginning of your breadcrumb'),
     '#options' => menu_get_menus(),
     '#description' => t('By default this is set to be the breadcrumb menu provided by the NextEuropa platform'),
-    '#default_value' => theme_get_setting('ec_europa_breadcrumb_menu'),
+    '#default_value' => theme_get_setting('ec_europa_breadcrumb_menu', 'europa'),
   ];
 
   $form['europa']['ec_europa_improved_website'] = [
@@ -30,5 +30,19 @@ function europa_form_system_theme_settings_alter(&$form, &$form_state) {
     '#title' => t('Is this an "improved website"?'),
     '#description' => t('If this website is an "improved" one we are agoing to show a site identification element in the page header'),
     '#default_value' => theme_get_setting('ec_europa_improved_website', 'europa'),
+  ];
+
+  $form['europa']['ec_europa_improved_website_home'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Do you want to show the site identification also in the home page?'),
+    '#description' => t('The site identifcation could duplicate your page title in homepage, you can hide it.'),
+    '#default_value' => theme_get_setting('ec_europa_improved_website_home', 'europa'),
+    '#states' => [
+      'visible' => [
+        ':input[name="ec_europa_improved_website"]' => [
+          'checked' => TRUE,
+        ],
+      ],
+    ],
   ];
 }

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -19,23 +19,23 @@ function europa_form_system_theme_settings_alter(&$form, &$form_state) {
 
   $form['europa']['ec_europa_breadcrumb_menu'] = [
     '#type' => 'select',
-    '#title' => t('Check the menu to be used at the beginning of your breadcrumb'),
+    '#title' => t('Check the menu to be used at the beginning of your breadcrumb.'),
     '#options' => menu_get_menus(),
-    '#description' => t('By default this is set to be the breadcrumb menu provided by the NextEuropa platform'),
+    '#description' => t('By default this is set to be the breadcrumb menu provided by the NextEuropa platform.'),
     '#default_value' => theme_get_setting('ec_europa_breadcrumb_menu', 'europa'),
   ];
 
   $form['europa']['ec_europa_improved_website'] = [
     '#type' => 'checkbox',
     '#title' => t('Is this an "improved website"?'),
-    '#description' => t('If this website is an "improved" one we are agoing to show a site identification element in the page header'),
+    '#description' => t('If this website is an "improved" one, we are going to show a site identification element in the page header.'),
     '#default_value' => theme_get_setting('ec_europa_improved_website', 'europa'),
   ];
 
   $form['europa']['ec_europa_improved_website_home'] = [
     '#type' => 'checkbox',
     '#title' => t('Do you want to show the site identification also in the home page?'),
-    '#description' => t('The site identifcation could duplicate your page title in homepage, you can hide it.'),
+    '#description' => t('The site identification could duplicate your page title in homepage, you can hide it.'),
     '#default_value' => theme_get_setting('ec_europa_improved_website_home', 'europa'),
     '#states' => [
       'visible' => [


### PR DESCRIPTION
Please review this together with https://github.com/ec-europa/ec-europa-theme-tools/pull/49/files
It is adding a setting in the theme admin page for hiding the site identification in the home page for those websites that use to have a page title = site name in order to avoid a duplication.
In the other pull request the same logic has been applied to all the ds templates including the page header